### PR TITLE
resholve: adapt to marking of py2 setuptools CVE

### DIFF
--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -33,6 +33,9 @@ let
     stripIdlelib = true;
     stripTests = true;
     enableOptimizations = false;
+    packageOverrides = prev: final: {
+      setuptools = (removeKnownVulnerabilities final.setuptools);
+    };
   };
   callPackage = lib.callPackageWith (pkgsBuildHost // { python27 = python27'; });
   source = callPackage ./source.nix { };


### PR DESCRIPTION
Does this look like you'd expect re: https://github.com/NixOS/nixpkgs/pull/514919#issuecomment-4364960239?